### PR TITLE
Implement event date picker and card filtering

### DIFF
--- a/mobile/Screen/EventScreen.js
+++ b/mobile/Screen/EventScreen.js
@@ -1,9 +1,13 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   StyleSheet,
   ScrollView,
+  Button,
+  View,
+  Text,
 } from 'react-native';
 import PropTypes from 'prop-types';
+import CalendarPicker from 'react-native-calendar-picker';
 import EventCard from '../Components/EventCard';
 import ResourceCard from '../Components/ResourceCard';
 
@@ -11,12 +15,18 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
+  buttonContainer: {
+    backgroundColor: '#DDDDDD',
+    borderRadius: 4,
+    margin: 20,
+    padding: 5,
+  },
 });
 
 const events = [{
   id: 1,
   title: 'Volunteering',
-  date: '10/03/2023',
+  date: new Date('2023-03-01T20:00:00.000Z'),
   day: 'Monday',
   location: '3148 Rose Rd, LA',
   organizations: 'BPlate',
@@ -31,7 +41,7 @@ const events = [{
 {
   id: 2,
   title: 'Fundraiser',
-  date: '09/08/2023',
+  date: new Date('2023-03-03T20:00:00.000Z'),
   day: 'Tuesday',
   location: '4102 Daisy Rd, LA',
   organizations: 'Studio 526',
@@ -46,7 +56,7 @@ const events = [{
 {
   id: 3,
   title: 'Information Session',
-  date: '03/05/2023',
+  date: new Date('2023-03-05T20:00:00.000Z'),
   day: 'Wednesday',
   location: '4123 Blue Rd, LA',
   organizations: 'Cafe 1919',
@@ -100,15 +110,51 @@ const resources = [
 ];
 
 function EventScreen({ navigation }) {
+  const [showCalendar, setShowCalendar] = useState(false);
+  const [selectedDate, setSelectedDate] = useState(null);
+
+  const handleButtonPress = () => {
+    setShowCalendar(!showCalendar);
+  };
+
+  const handleDateSelect = (date) => {
+    setSelectedDate(date);
+    setShowCalendar(false);
+  };
+
+  const filteredEvents = events.filter(
+    (event) => !selectedDate || new Date(event.date) >= new Date(selectedDate),
+  );
+
   return (
     <ScrollView style={styles.scrollView}>
-      {/* <Text>Map Screen</Text>
-      <Button title="Test" onPress={test} /> */}
-      {events.map((event) => (
+      <View style={styles.buttonContainer}>
+        <Button
+          title="Select date"
+          color="#4C4C9B"
+          accessibilityLabel="Go to date picker"
+          onPress={handleButtonPress}
+        />
+      </View>
+      {showCalendar && (
+        <CalendarPicker
+          onDateChange={handleDateSelect}
+          selectedStartDate={selectedDate}
+          selectedEndDate={selectedDate}
+        />
+      )}
+      {selectedDate !== null && (
+        <Text style={{ textAlign: 'center' }}>
+          Date selected:
+          {' '}
+          { JSON.stringify(selectedDate).slice(1, 11) }
+        </Text>
+      )}
+      {filteredEvents.map((event) => (
         <EventCard
           id={event.id}
           title={event.title}
-          date={event.date}
+          date={event.date.toLocaleDateString('en-US')}
           day={event.day}
           location={event.location}
           time={event.time}

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -23,6 +23,7 @@
     "prop-types": "^15.8.1",
     "react": "18.1.0",
     "react-native": "0.70.5",
+    "react-native-calendar-picker": "^7.1.4",
     "react-native-dotenv": "^3.4.2",
     "react-native-gesture-handler": "~2.8.0",
     "react-native-maps": "1.3.2",


### PR DESCRIPTION
- Used [react-native-calendar-picker](https://github.com/stephy/CalendarPicker)
- Clicking _Select date_ opens the calendar. Clicking _Select date_ again or actually selecting a date automatically closes the calendar. When a date is selected, the date background turns green and text near the top of the screen shows what was chosen; filtering also occurs as only events on or after that date are displayed below. To unselect a date, click on the date again.
- Notes: I only implemented filtering for Events, not Resources, because Resources don't have a defined date. Also, current implementation is built on hard-coded data, which will need to be fixed in the future.

https://user-images.githubusercontent.com/65837446/222654480-40c3ff97-8c63-4445-9637-a2e02744f9cd.mov